### PR TITLE
Add Jest tests for createDraggableElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# VBoard
+
+This project is a minimal vision board application.
+
+## Running Tests
+
+Install dependencies and run the test suite:
+
+```bash
+npm install
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "vboard",
+  "version": "1.0.0",
+  "description": "Vision board web app",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -158,4 +158,9 @@ const firebaseConfig = {
       saveUserBoard(user.uid);
     }
   });
+
+// Export for testing
+if (typeof module !== 'undefined') {
+  module.exports = { createDraggableElement };
+}
   

--- a/tests/createDraggableElement.test.js
+++ b/tests/createDraggableElement.test.js
@@ -1,0 +1,46 @@
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div id="board"></div>
+    <button id="searchButton"></button>
+    <input id="searchQuery" />
+    <div id="searchResults"></div>
+    <button id="addTextButton"></button>
+    <button id="saveButton"></button>
+    <button id="loginButton"></button>
+    <button id="logoutButton"></button>
+  `;
+
+  global.firebase = {
+    initializeApp: jest.fn(),
+    auth: jest.fn(() => ({ signInWithPopup: jest.fn() })),
+    firestore: jest.fn(() => ({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          set: jest.fn(),
+          get: jest.fn(() => Promise.resolve({ exists: false }))
+        }))
+      }))
+    }))
+  };
+  global.firebase.auth.GoogleAuthProvider = function() {};
+
+  global.html2canvas = jest.fn(() => Promise.resolve({ toDataURL: jest.fn() }));
+  global.jspdf = { jsPDF: function() { return { addImage: jest.fn(), save: jest.fn() }; } };
+
+  const dummyInteractable = {
+    draggable: jest.fn(() => dummyInteractable),
+    resizable: jest.fn(() => dummyInteractable)
+  };
+  global.interact = jest.fn(() => dummyInteractable);
+
+  jest.resetModules();
+});
+
+test('createDraggableElement adds text node to board', () => {
+  const { createDraggableElement } = require('../script');
+  createDraggableElement('text', 'hello');
+  const board = document.getElementById('board');
+  const el = board.querySelector('.draggable');
+  expect(el).not.toBeNull();
+  expect(el.textContent).toBe('hello');
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest and jsdom
- export `createDraggableElement` for testing
- create Jest test for draggable text element
- add README with instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68428d7ce41c8329a065632d3098c7f2